### PR TITLE
Sprint2/drawer

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ Navigate to http://localhost:8081
 
 # Project Structure
 This project uses [Expo Router](https://docs.expo.dev/router/create-pages/) to define pages in the file-based routing convention.
+
+More specifically, it leverages the [Expo Drawer](https://dev.to/aaronksaunders/expo-router-drawer-navigation-from-the-docs-231k) for the user to easily navigate between pages such as Settings.

--- a/app.json
+++ b/app.json
@@ -7,6 +7,7 @@
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
     "scheme": "brixcolor.com",
+    "backgroundColor": "#000000",
     "splash": {
       "image": "./assets/splash.png",
       "resizeMode": "contain",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "brixcolor",
       "version": "1.0.0",
       "dependencies": {
+        "@react-navigation/drawer": "^6.6.15",
         "@types/react": "~18.2.45",
         "expo": "~50.0.6",
         "expo-camera": "~14.1.1",
@@ -18,6 +19,8 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-native": "0.73.4",
+        "react-native-gesture-handler": "~2.14.0",
+        "react-native-reanimated": "~3.6.2",
         "react-native-safe-area-context": "4.8.2",
         "react-native-screens": "~3.29.0",
         "react-native-web": "~0.19.6",
@@ -275,9 +278,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-      "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.0.tgz",
+      "integrity": "sha512-9cUznXMG0+FxRuJfvL82QlTqIzhVW9sL0KjMPHhAOOvpQGL8QtdxnBKILjBqxlHyliz0yCa1G903ZXI/FuHy2w==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1369,6 +1372,20 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-object-assign": {
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.24.1.tgz",
+      "integrity": "sha512-I1kctor9iKtupb7jv7FyjApHCuKLBKCblVAeHVK9PB6FW7GI0ac6RtobC3MwwJy8CZ1JxuhQmnbrsqI5G8hAIg==",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.24.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-object-rest-spread": {
       "version": "7.23.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.23.4.tgz",
@@ -2014,6 +2031,17 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "dependencies": {
+        "@types/hammerjs": "^2.0.36"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@expo/bunyan": {
@@ -5950,10 +5978,29 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/@react-navigation/drawer": {
+      "version": "6.6.15",
+      "resolved": "https://registry.npmjs.org/@react-navigation/drawer/-/drawer-6.6.15.tgz",
+      "integrity": "sha512-GLkFQNxjtmxB/qXSHmu1DfoB89jCzW64tmX68iPndth+9U+0IP27GcCCaMZxQfwj+nI8Kn2zlTlXAZDIIHE+DQ==",
+      "dependencies": {
+        "@react-navigation/elements": "^1.3.30",
+        "color": "^4.2.3",
+        "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^6.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-gesture-handler": ">= 1.0.0",
+        "react-native-reanimated": ">= 1.0.0",
+        "react-native-safe-area-context": ">= 3.0.0",
+        "react-native-screens": ">= 3.0.0"
+      }
+    },
     "node_modules/@react-navigation/elements": {
-      "version": "1.3.29",
-      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.29.tgz",
-      "integrity": "sha512-sMkqqQHlxdBxrBVw6E2a3LJjb9Hrb1ola8+zRgJn4Ox8iKtjqtWEdg349DPWU77VpIekcMLsqQvEtZox3XkXgA==",
+      "version": "1.3.30",
+      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.30.tgz",
+      "integrity": "sha512-plhc8UvCZs0UkV+sI+3bisIyn78wz9O/BiWZXpounu72k/R/Sj5PuZYFJ1fi6psvriUveMCGh4LeZckAZu2qiQ==",
       "peerDependencies": {
         "@react-navigation/native": "^6.0.0",
         "react": "*",
@@ -6157,6 +6204,11 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
       "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
+    },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.45",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.45.tgz",
+      "integrity": "sha512-qkcUlZmX6c4J8q45taBKTL3p+LbITgyx7qhlPYOdOHZB7B31K0mXbP5YA7i7SgDeEGuI9MnumiKPEMrxg8j3KQ=="
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -8695,6 +8747,19 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hosted-git-info": {
       "version": "3.0.8",
@@ -12036,6 +12101,43 @@
       },
       "peerDependencies": {
         "react": "18.2.0"
+      }
+    },
+    "node_modules/react-native-gesture-handler": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.14.1.tgz",
+      "integrity": "sha512-YiM1BApV4aKeuwsM6O4C2ufwewYEKk6VMXOt0YqEZFMwABBFWhXLySFZYjBSNRU2USGppJbfHP1q1DfFQpKhdA==",
+      "dependencies": {
+        "@egjs/hammerjs": "^2.0.17",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-reanimated": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.6.3.tgz",
+      "integrity": "sha512-2KkkPozoIvDbJcHuf8qeyoLROXQxizSi+2CTCkuNVkVZOxxY4B0Omvgq61aOQhSZUh/649x1YHoAaTyGMGDJUw==",
+      "dependencies": {
+        "@babel/plugin-transform-object-assign": "^7.16.7",
+        "@babel/preset-typescript": "^7.16.7",
+        "convert-source-map": "^2.0.0",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0-0",
+        "@babel/plugin-proposal-optional-chaining": "^7.0.0-0",
+        "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
+        "@babel/plugin-transform-template-literals": "^7.0.0-0",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-safe-area-context": {

--- a/package.json
+++ b/package.json
@@ -10,20 +10,23 @@
     "ts:check": "tsc"
   },
   "dependencies": {
+    "@react-navigation/drawer": "^6.6.15",
+    "@types/react": "~18.2.45",
     "expo": "~50.0.6",
+    "expo-camera": "~14.1.1",
+    "expo-constants": "~15.4.5",
+    "expo-linking": "~6.2.2",
+    "expo-router": "~3.4.8",
     "expo-status-bar": "~1.11.1",
     "react": "18.2.0",
+    "react-dom": "18.2.0",
     "react-native": "0.73.4",
-    "typescript": "^5.3.0",
-    "@types/react": "~18.2.45",
-    "expo-router": "~3.4.8",
+    "react-native-gesture-handler": "~2.14.0",
+    "react-native-reanimated": "~3.6.2",
     "react-native-safe-area-context": "4.8.2",
     "react-native-screens": "~3.29.0",
-    "expo-linking": "~6.2.2",
-    "expo-constants": "~15.4.5",
     "react-native-web": "~0.19.6",
-    "react-dom": "18.2.0",
-    "expo-camera": "~14.1.1"
+    "typescript": "^5.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/src/app/(drawer)/_layout.tsx
+++ b/src/app/(drawer)/_layout.tsx
@@ -1,0 +1,28 @@
+import {Drawer} from "expo-router/drawer";
+
+export default function DrawerLayout() {
+    return (
+        <Drawer
+            screenOptions={{ headerShown: false, swipeEdgeWidth: 0}}
+        >
+
+            <Drawer.Screen
+                name="scan"
+                options={{
+                    drawerLabel: "Scan",
+                    headerShown: false,
+                }}
+            />
+
+            <Drawer.Screen
+                name="settings"
+                options={{
+                    drawerLabel: "Settings",
+                    title: 'Settings',
+                    headerShown: true,
+                }}
+            />
+
+        </Drawer>
+    );
+}

--- a/src/app/(drawer)/scan/_layout.tsx
+++ b/src/app/(drawer)/scan/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from "expo-router";
+
+export default function ScanLayout() {
+    return <Stack />;
+}

--- a/src/app/(drawer)/scan/index.tsx
+++ b/src/app/(drawer)/scan/index.tsx
@@ -1,0 +1,68 @@
+import { StatusBar } from 'expo-status-bar';
+import { StyleSheet, View, Pressable } from 'react-native';
+import ScanCamera from "@/components/ScanCamera";
+import BrixText from "@/components/BrixText";
+import pageStyles from "@/styles/page";
+import buttonStyles from "@/styles/button";
+import { DrawerToggleButton } from "@react-navigation/drawer";
+import {Drawer} from "expo-router/drawer";
+
+export default function Page() {
+    return (
+        <View style={pageStyles.container}>
+            <Drawer.Screen
+                options={{
+                    headerShown: false,
+                }}
+            />
+
+            <View style={pageStyles.header}>
+                <DrawerToggleButton/>
+
+                <Pressable style={[buttonStyles.placeholder, {marginRight: 15}]}>
+                    <BrixText>Help</BrixText>
+                </Pressable>
+            </View>
+
+            <ScanCamera style={styles.camera}>
+                <View style={styles.control}>
+                    <Pressable style={[buttonStyles.placeholder]}>
+                        <BrixText>Flash</BrixText>
+                    </Pressable>
+
+                    <Pressable style={[buttonStyles.placeholder]}>
+                        <BrixText>Shutter</BrixText>
+                    </Pressable>
+
+                    <Pressable style={[buttonStyles.placeholder]}>
+                        <BrixText>Open</BrixText>
+                    </Pressable>
+                </View>
+            </ScanCamera>
+
+            <StatusBar style="auto" />
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    camera: {
+        flex: 10,
+        alignItems: 'center',
+        justifyContent: 'center',
+
+        fontWeight: 'bold',
+        fontSize: 48,
+        width: '100%',
+    },
+
+    control: {
+        flex: 3/8,
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 30,
+        backgroundColor: 'rgba(0,0,0,0.375)',
+        marginTop: 'auto'
+    },
+});

--- a/src/app/(drawer)/settings/_layout.tsx
+++ b/src/app/(drawer)/settings/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from "expo-router";
+
+export default function SettingsLayout() {
+    return <Stack />;
+}

--- a/src/app/(drawer)/settings/index.tsx
+++ b/src/app/(drawer)/settings/index.tsx
@@ -1,0 +1,15 @@
+import {View} from "react-native";
+import BrixText from "@/components/BrixText";
+import pageStyles from "@/styles/page";
+import {Drawer} from "expo-router/drawer";
+
+export default function Settings() {
+    return (<View style={pageStyles.container}>
+        <Drawer.Screen
+            options={{
+                headerShown: false,
+            }}
+        />
+        <BrixText>Settings</BrixText>
+    </View>)
+}

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,35 +1,85 @@
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, View } from 'react-native';
-import HelloWorld from "@/components/HelloWorld";
-import Icons from "@icons";
-import {SendIcon} from "@icons"
-import {Link} from "expo-router";
+import { StyleSheet, View, Pressable } from 'react-native';
 import ScanCamera from "@/components/ScanCamera";
+import BrixText from "@/components/BrixText";
 
 export default function App() {
     return (
         <View style={styles.container}>
+            <View style={styles.header}>
+                <Pressable style={[buttons.placeholder, {marginLeft: 15}]}>
+                    <BrixText>Open Menu</BrixText>
+                </Pressable>
 
-            <ScanCamera/>
+                <Pressable style={[buttons.placeholder, {marginRight: 15}]}>
+                    <BrixText>Help</BrixText>
+                </Pressable>
+            </View>
 
-            <HelloWorld/>
+            <ScanCamera style={styles.camera}>
+                <View style={styles.control}>
+                    <Pressable style={[buttons.placeholder]}>
+                        <BrixText>Flash</BrixText>
+                    </Pressable>
 
-            {/*Two ways of using the same component*/}
-            <Icons.Send/>
-            <SendIcon/>
+                    <Pressable style={[buttons.placeholder]}>
+                        <BrixText>Shutter</BrixText>
+                    </Pressable>
+
+                    <Pressable style={[buttons.placeholder]}>
+                        <BrixText>Open</BrixText>
+                    </Pressable>
+                </View>
+            </ScanCamera>
+
             <StatusBar style="auto" />
-
-            {/*Link that navigates to /settings*/}
-            <Link href="/settings">Settings</Link>
         </View>
     );
 }
 
 const styles = StyleSheet.create({
+    header: {
+        flex: 1,
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        width: '100%',
+        backgroundColor: 'black',
+    },
+
     container: {
         flex: 1,
-        backgroundColor: '#fff',
         alignItems: 'center',
         justifyContent: 'center',
+        backgroundColor: 'black'
+    },
+
+    camera: {
+        flex: 10,
+        alignItems: 'center',
+        justifyContent: 'center',
+
+        fontWeight: 'bold',
+        fontSize: 48,
+        width: '100%',
+    },
+
+    control: {
+        flex: 3/8,
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 30,
+        backgroundColor: 'rgba(0,0,0,0.375)',
+        marginTop: 'auto'
     },
 });
+
+const buttons = StyleSheet.create({
+    placeholder: {
+        borderStyle: 'solid',
+        borderWidth: 2,
+        padding: 4,
+        borderColor: 'white'
+    }
+})

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,62 +1,7 @@
-import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, View, Pressable } from 'react-native';
-import ScanCamera from "@/components/ScanCamera";
-import BrixText from "@/components/BrixText";
-import pageStyles from "@/styles/page";
-import buttonStyles from "@/styles/button";
+import {Redirect} from "expo-router";
 
 export default function App() {
     return (
-        <View style={pageStyles.container}>
-            <View style={pageStyles.header}>
-                <Pressable style={[buttonStyles.placeholder, {marginLeft: 15}]}>
-                    <BrixText>Open Menu</BrixText>
-                </Pressable>
-
-                <Pressable style={[buttonStyles.placeholder, {marginRight: 15}]}>
-                    <BrixText>Help</BrixText>
-                </Pressable>
-            </View>
-
-            <ScanCamera style={styles.camera}>
-                <View style={styles.control}>
-                    <Pressable style={[buttonStyles.placeholder]}>
-                        <BrixText>Flash</BrixText>
-                    </Pressable>
-
-                    <Pressable style={[buttonStyles.placeholder]}>
-                        <BrixText>Shutter</BrixText>
-                    </Pressable>
-
-                    <Pressable style={[buttonStyles.placeholder]}>
-                        <BrixText>Open</BrixText>
-                    </Pressable>
-                </View>
-            </ScanCamera>
-
-            <StatusBar style="auto" />
-        </View>
+        <Redirect href="/login" />
     );
 }
-
-const styles = StyleSheet.create({
-    camera: {
-        flex: 10,
-        alignItems: 'center',
-        justifyContent: 'center',
-
-        fontWeight: 'bold',
-        fontSize: 48,
-        width: '100%',
-    },
-
-    control: {
-        flex: 3/8,
-        flexDirection: 'row',
-        alignItems: 'center',
-        justifyContent: 'center',
-        gap: 30,
-        backgroundColor: 'rgba(0,0,0,0.375)',
-        marginTop: 'auto'
-    },
-});

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -2,31 +2,33 @@ import { StatusBar } from 'expo-status-bar';
 import { StyleSheet, View, Pressable } from 'react-native';
 import ScanCamera from "@/components/ScanCamera";
 import BrixText from "@/components/BrixText";
+import pageStyles from "@/styles/page";
+import buttonStyles from "@/styles/button";
 
 export default function App() {
     return (
-        <View style={styles.container}>
-            <View style={styles.header}>
-                <Pressable style={[buttons.placeholder, {marginLeft: 15}]}>
+        <View style={pageStyles.container}>
+            <View style={pageStyles.header}>
+                <Pressable style={[buttonStyles.placeholder, {marginLeft: 15}]}>
                     <BrixText>Open Menu</BrixText>
                 </Pressable>
 
-                <Pressable style={[buttons.placeholder, {marginRight: 15}]}>
+                <Pressable style={[buttonStyles.placeholder, {marginRight: 15}]}>
                     <BrixText>Help</BrixText>
                 </Pressable>
             </View>
 
             <ScanCamera style={styles.camera}>
                 <View style={styles.control}>
-                    <Pressable style={[buttons.placeholder]}>
+                    <Pressable style={[buttonStyles.placeholder]}>
                         <BrixText>Flash</BrixText>
                     </Pressable>
 
-                    <Pressable style={[buttons.placeholder]}>
+                    <Pressable style={[buttonStyles.placeholder]}>
                         <BrixText>Shutter</BrixText>
                     </Pressable>
 
-                    <Pressable style={[buttons.placeholder]}>
+                    <Pressable style={[buttonStyles.placeholder]}>
                         <BrixText>Open</BrixText>
                     </Pressable>
                 </View>
@@ -38,22 +40,6 @@ export default function App() {
 }
 
 const styles = StyleSheet.create({
-    header: {
-        flex: 1,
-        flexDirection: 'row',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        width: '100%',
-        backgroundColor: 'black',
-    },
-
-    container: {
-        flex: 1,
-        alignItems: 'center',
-        justifyContent: 'center',
-        backgroundColor: 'black'
-    },
-
     camera: {
         flex: 10,
         alignItems: 'center',
@@ -74,12 +60,3 @@ const styles = StyleSheet.create({
         marginTop: 'auto'
     },
 });
-
-const buttons = StyleSheet.create({
-    placeholder: {
-        borderStyle: 'solid',
-        borderWidth: 2,
-        padding: 4,
-        borderColor: 'white'
-    }
-})

--- a/src/app/login.tsx
+++ b/src/app/login.tsx
@@ -1,0 +1,12 @@
+import {View} from "react-native";
+import {Link} from "expo-router";
+import BrixText from "@/components/BrixText";
+import pageStyles from "@/styles/page";
+
+export default function Login() {
+    return (<View style={pageStyles.container}>
+        <Link href="/(drawer)/scan">
+            <BrixText>Login</BrixText>
+        </Link>
+    </View>)
+}

--- a/src/app/settings.tsx
+++ b/src/app/settings.tsx
@@ -1,7 +1,0 @@
-import {View} from "react-native";
-
-export default function Settings() {
-    return (<View>
-        Settings
-    </View>)
-}

--- a/src/components/BrixText.tsx
+++ b/src/components/BrixText.tsx
@@ -1,0 +1,14 @@
+import {StyleSheet, Text, TextProps} from "react-native";
+
+export default function BrixText(props: TextProps) {
+    return (<>
+            <Text style={[styles.brixText, props.style]}>{props.children}</Text>
+    </>)
+}
+
+const styles = StyleSheet.create({
+    brixText: {
+        fontWeight: 'bold',
+        color: 'white',
+    }
+})

--- a/src/components/ScanCamera.tsx
+++ b/src/components/ScanCamera.tsx
@@ -1,7 +1,7 @@
-import {Button, StyleSheet, Text, View} from "react-native";
+import {Button, Text, View, ViewProps} from "react-native";
 import {Camera, CameraType} from "expo-camera";
 
-export default function ScanCamera() {
+export default function ScanCamera(props: ViewProps) {
     const [permission, requestPermission] = Camera.useCameraPermissions()
 
     if (!permission) {
@@ -10,7 +10,7 @@ export default function ScanCamera() {
     }
 
     if (!permission.granted) {
-        return (<View>
+        return (<View style={props.style}>
             <Text>Please grant access to camera usage in app settings.</Text>
             <Button
                 title="Request Permission"
@@ -20,23 +20,10 @@ export default function ScanCamera() {
     }
 
     return (<>
-        <View style={styles.container}>
-            <Camera style={styles.camera} type={CameraType.back}>
-                <View>
-
-                </View>
+        <View style={[props.style, {backgroundColor: 'black'}]}>
+            <Camera style={{width: '100%', height: '100%'}} type={CameraType.back}>
+                {props.children}
             </Camera>
         </View>
     </>)
 }
-
-const styles = StyleSheet.create({
-    container: {
-        width: '100%',
-        height: '50%',
-    },
-
-    camera: {
-        flex: 1
-    }
-})

--- a/src/styles/button.ts
+++ b/src/styles/button.ts
@@ -1,0 +1,12 @@
+import {StyleSheet} from "react-native";
+
+const buttonStyles = StyleSheet.create({
+    placeholder: {
+        borderStyle: 'solid',
+        borderWidth: 2,
+        padding: 4,
+        borderColor: 'white'
+    }
+})
+
+export default buttonStyles

--- a/src/styles/page.ts
+++ b/src/styles/page.ts
@@ -1,0 +1,21 @@
+import {StyleSheet} from "react-native";
+
+const pageStyles = StyleSheet.create({
+    header: {
+        flex: 1,
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        width: '100%',
+        backgroundColor: 'black',
+    },
+
+    container: {
+        flex: 1,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: 'black'
+    },
+})
+
+export default pageStyles


### PR DESCRIPTION
Uses `expo-router/drawer` to create the slide out menu. A lot of files moved in order to be compatible with the drawer.

Summary
- Application now redirects to the login page when first opened. From login it redirects to the Scan page.
- For now, drawer can open either the Scan page or the Settings page.
- Login and Settings page are still skeleton UIs.

![image](https://github.com/Losing-To-Bugs/BrixColor/assets/67762761/fd4a862f-7f77-48b9-8d26-5289663defc6)
